### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/Certera.Data/Certera.Data.csproj
+++ b/src/Certera.Data/Certera.Data.csproj
@@ -6,16 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Certes" Version="2.3.3" />
+    <PackageReference Include="Certes" Version="2.3.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@certeraio, I found an issue in the Certera.Data.csproj:

Packages Certes v2.3.3, Microsoft.AspNetCore.Identity.EntityFrameworkCore v3.1.0, Microsoft.EntityFrameworkCore v3.1.0, Microsoft.EntityFrameworkCore.Design v3.1.0, Microsoft.EntityFrameworkCore.Sqlite v3.1.0 and Microsoft.EntityFrameworkCore.Tools v3.1.0 transitively introduce 107 dependencies into certera’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/certera.html)), while Certes v2.3.4, Microsoft.AspNetCore.Identity.EntityFrameworkCore v3.1.1, Microsoft.EntityFrameworkCore v3.1.16, Microsoft.EntityFrameworkCore.Design v3.1.5, Microsoft.EntityFrameworkCore.Sqlite v3.1.1 and Microsoft.EntityFrameworkCore.Tools v3.1.1 can only introduce 73 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/certera_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose